### PR TITLE
file_tree: change some `to_*` functions to `as_*`

### DIFF
--- a/file-tree/src/file_tree.rs
+++ b/file-tree/src/file_tree.rs
@@ -425,7 +425,7 @@ impl<T> FileTree<T> {
         matches!(self, Self::Symlink { .. })
     }
 
-    pub fn to_regular(&mut self) {
+    pub fn as_regular(&mut self) {
         match self {
             Self::Regular { .. } => {},
             Self::Directory { path, extra, .. } | Self::Symlink { path, extra, .. } => {
@@ -436,7 +436,7 @@ impl<T> FileTree<T> {
         }
     }
 
-    pub fn to_directory(&mut self, children: Vec<Self>) {
+    pub fn as_directory(&mut self, children: Vec<Self>) {
         match self {
             Self::Regular { path, extra }
             | Self::Directory { path, extra, .. }
@@ -448,7 +448,7 @@ impl<T> FileTree<T> {
         }
     }
 
-    pub fn to_symlink(&mut self, target_path: impl AsRef<Path>) {
+    pub fn as_symlink(&mut self, target_path: impl AsRef<Path>) {
         match self {
             Self::Regular { path, extra }
             | Self::Directory { path, extra, .. }

--- a/tsml/src/parser.rs
+++ b/tsml/src/parser.rs
@@ -99,7 +99,7 @@ pub fn parse_tokens(
 
                 if let Some((LexToken::SymlinkArrow, _)) = tokens_iter.peek() {
                     if let Some((LexToken::Value(target), _)) = tokens_iter.nth(1) {
-                        file.to_symlink(target);
+                        file.as_symlink(target);
                     } else {
                         return Err(ParserError::new(
                             current_line,
@@ -132,7 +132,7 @@ pub fn parse_tokens(
                 assert!(!file_stack.is_empty());
 
                 depth += 1;
-                file_stack.last_mut().unwrap().to_directory(vec![]);
+                file_stack.last_mut().unwrap().as_directory(vec![]);
                 quantity_stack.push(0);
                 already_read_some_lmao = false;
             },
@@ -158,7 +158,7 @@ pub fn parse_tokens(
                 // Reversed
                 let vec = vec.into_iter().rev().collect();
 
-                file_stack.last_mut().expect("should").to_directory(vec);
+                file_stack.last_mut().expect("should").as_directory(vec);
             },
 
             LexToken::Separator(separator) => {


### PR DESCRIPTION
Methods called `to_*` usually take self by reference, so changing these functions to 'as_*` _should_ be closer to the standard